### PR TITLE
fix: remove deprecated shell and lsp config

### DIFF
--- a/config/plugins/lsp/lsp.nix
+++ b/config/plugins/lsp/lsp.nix
@@ -294,39 +294,4 @@
     ansible-vim
   ];
 
-  extraConfigLua = ''
-    local _border = "rounded"
-
-    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
-      vim.lsp.handlers.hover, {
-        border = _border
-      }
-    )
-
-    vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(
-      vim.lsp.handlers.signature_help, {
-        border = _border
-      }
-    )
-
-    vim.diagnostic.config{
-      float={border=_border}
-    };
-
-    require('lspconfig.ui.windows').default_options = {
-      border = _border
-    }
-
-    -- LSP UI enhancements
-    local signs = {
-      Error = "󰅚 ",
-      Warn = "󰀪 ",
-      Hint = "󰌶 ",
-      Info = "󰋽 "
-    }
-    for type, icon in pairs(signs) do
-      local hl = "DiagnosticSign" .. type
-      vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
-    end
-  '';
 }

--- a/config/settings.nix
+++ b/config/settings.nix
@@ -8,16 +8,6 @@
         vim.fn.sign_define("diagnosticsignhint", { text = "󰌵", texthl = "diagnostichint", linehl = "", numhl = "" })
         vim.fn.sign_define("diagnosticsigninfo", { text = " ", texthl = "diagnosticinfo", linehl = "", numhl = "" })
 
-        -- Shell configuration
-        if os.execute("nu --version") == 0 then
-          -- nu
-          vim.opt.shell = "nu"
-          vim.opt.shellcmdflag = "-c"
-        elseif vim.fn.has("win32") == 1 and os.execute("pwsh --version") == 0 then
-          -- pwsh (Powershell 7)
-          vim.opt.shell = "pwsh.exe -NoLogo"
-          vim.opt.shellcmdflag = "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
-        end
 
         -- Neovide configuration
         if vim.g.neovide then


### PR DESCRIPTION
- Remove nu/pwsh shell configuration from settings.nix
- Remove deprecated vim.lsp.with() handlers from lsp.nix

Note: E5113 nil value error is pre-existing in the codebase