### PR TITLE
refactor: extract substituters config into centralized substituters.toml

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Parse substituters config
+        id: subs
+        shell: python
+        run: |
+          import tomllib, os
+          with open("substituters.toml", "rb") as f:
+              data = tomllib.load(f)
+          subs = [s["url"] for s in data["substituters"] if ".cn/" not in s["url"]]
+          keys = [s["public-key"] for s in data["substituters"] if "public-key" in s]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"substituters={' '.join(subs)}\n")
+              out.write(f"trusted-public-keys={' '.join(keys)}\n")
+
       - name: Install nix
         uses: cachix/install-nix-action@v31
         with:
@@ -21,8 +34,9 @@ jobs:
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             extra-platforms = aarch64-linux x86_64-darwin aarch64-darwin
-            substituters = https://nix-community.cachix.org/ https://cache.nixos.org/
-            trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            accept-flake-config = false
+            substituters = ${{ steps.subs.outputs.substituters }}
+            trusted-public-keys = ${{ steps.subs.outputs.trusted-public-keys }}
 
       - name: Show nixpkgs version
         run: nix eval --impure --raw --expr "(import (builtins.getFlake \"path:${PWD}\").inputs.nixpkgs {}).lib.version"
@@ -30,11 +44,27 @@ jobs:
       - name: Flake check
         run: nix flake check --show-trace --keep-going
 
+      - name: Format check
+        run: nix fmt -- --fail-on-change
+
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Parse substituters config
+        id: subs
+        shell: python
+        run: |
+          import tomllib, os
+          with open("substituters.toml", "rb") as f:
+              data = tomllib.load(f)
+          subs = [s["url"] for s in data["substituters"] if ".cn/" not in s["url"]]
+          keys = [s["public-key"] for s in data["substituters"] if "public-key" in s]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"substituters={' '.join(subs)}\n")
+              out.write(f"trusted-public-keys={' '.join(keys)}\n")
 
       - name: Install nix
         uses: cachix/install-nix-action@v31
@@ -42,8 +72,9 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            substituters = https://nix-community.cachix.org/ https://cache.nixos.org/
-            trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            accept-flake-config = false
+            substituters = ${{ steps.subs.outputs.substituters }}
+            trusted-public-keys = ${{ steps.subs.outputs.trusted-public-keys }}
 
       - name: Build
         run: |

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -20,14 +20,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Parse substituters config
+        id: subs
+        shell: python
+        run: |
+          import tomllib, os
+          with open("substituters.toml", "rb") as f:
+              data = tomllib.load(f)
+          subs = [s["url"] for s in data["substituters"] if ".cn/" not in s["url"]]
+          keys = [s["public-key"] for s in data["substituters"] if "public-key" in s]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"substituters={' '.join(subs)}\n")
+              out.write(f"trusted-public-keys={' '.join(keys)}\n")
+
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-            substituters = https://nix-community.cachix.org/ https://cache.nixos.org/
-            trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            accept-flake-config = false
+            substituters = ${{ steps.subs.outputs.substituters }}
+            trusted-public-keys = ${{ steps.subs.outputs.trusted-public-keys }}
 
       - name: Update flake.lock
         run: nix flake update

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,26 @@
 {
   description = "MiyakoMeow's NixVim configuration";
 
+  # The nixConfig here only affects the flake itself, not the system configuration!
+  # NOTE: Keep in sync with substituters.toml (nixConfig does not support computed values)
+  nixConfig = {
+    substituters = [
+      "https://mirrors.ustc.edu.cn/nix-channels/store"
+      "https://mirrors.sjtug.sjtu.edu.cn/nix-channels/store"
+      "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store"
+      "https://nix-community.cachix.org"
+      "https://miyakomeow.cachix.org"
+      "https://cache.garnix.io"
+      "https://cache.nixos.org"
+    ];
+    trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "miyakomeow.cachix.org-1:85k7pjjK1Voo+kMHJx8w3nT1rlBow3+4/M+LsAuMCRY="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/substituters.toml
+++ b/substituters.toml
@@ -1,0 +1,24 @@
+[[substituters]]
+url = "https://mirrors.ustc.edu.cn/nix-channels/store"
+
+[[substituters]]
+url = "https://mirrors.sjtug.sjtu.edu.cn/nix-channels/store"
+
+[[substituters]]
+url = "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store"
+
+[[substituters]]
+url = "https://nix-community.cachix.org"
+public-key = "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+
+[[substituters]]
+url = "https://miyakomeow.cachix.org"
+public-key = "miyakomeow.cachix.org-1:85k7pjjK1Voo+kMHJx8w3nT1rlBow3+4/M+LsAuMCRY="
+
+[[substituters]]
+url = "https://cache.garnix.io"
+public-key = "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+
+[[substituters]]
+url = "https://cache.nixos.org"
+public-key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="


### PR DESCRIPTION
## Summary

- Add `substituters.toml` synced with [nixos-config](https://github.com/MiyakoMeow/nixos-config) (see #60, #61)
- Add `nixConfig` to `flake.nix` with comment about keeping in sync with `substituters.toml`
- CI workflows parse `substituters.toml` with Python tomllib, excluding Chinese mirrors
- Add `nix fmt -- --fail-on-change` step to `flake-check` job