### PR TITLE
feat: enable catppuccin integrations for blink-cmp and snacks

### DIFF
--- a/plugins/theme/default.nix
+++ b/plugins/theme/default.nix
@@ -4,6 +4,9 @@
     settings = {
       flavour = "macchiato";
       integrations = {
+        blink_cmp = {
+          style = "bordered";
+        };
         bufferline = true;
         cmp = true;
         dap = true;
@@ -17,6 +20,9 @@
           enabled = true;
         };
         rainbow_delimiters = true;
+        snacks = {
+          enabled = true;
+        };
         treesitter = true;
         treesitter_context = true;
         which_key = true;


### PR DESCRIPTION
## Summary

Enable catppuccin integrations for two plugins already present in the config but missing from the theme integration list:

- **blink-cmp**: `blink_cmp` with `style = "bordered"` (matches the existing `completion.menu.border = "rounded"` setting)
- **snacks**: `snacks` with `enabled = true` (covers dashboard/picker/notifier/explorer/indent and all other snacks.nvim components)

## Changes

`plugins/theme/default.nix` — added 6 lines.

## Verification

- `nix flake check` — all checks passed
- Integration name references verified against catppuccin/nvim source (v4.x `CtpIntegrations` type)
- Existing integrations left untouched