### PR TITLE
refactor: remove treesitter-context and treesitter-textobjects

### DIFF
--- a/plugins/feature/treesitter.nix
+++ b/plugins/feature/treesitter.nix
@@ -1,27 +1,25 @@
 { pkgs, ... }:
 {
-  plugins = {
-    treesitter = {
-      enable = true;
+  plugins.treesitter = {
+    enable = true;
 
-      settings = {
-        indent = {
-          enable = true;
-        };
-        highlight = {
-          enable = true;
-        };
-        incremental_selection = {
-          enable = true;
-        };
+    settings = {
+      indent = {
+        enable = true;
       };
-
-      nixvimInjections = true;
-      grammarPackages = pkgs.vimPlugins.nvim-treesitter.allGrammars;
+      highlight = {
+        enable = true;
+      };
+      incremental_selection = {
+        enable = true;
+      };
     };
 
-    rainbow-delimiters = {
-      enable = true;
-    };
+    nixvimInjections = true;
+    grammarPackages = pkgs.vimPlugins.nvim-treesitter.allGrammars;
+  };
+
+  plugins.rainbow-delimiters = {
+    enable = true;
   };
 }

--- a/plugins/feature/treesitter.nix
+++ b/plugins/feature/treesitter.nix
@@ -20,25 +20,6 @@
       grammarPackages = pkgs.vimPlugins.nvim-treesitter.allGrammars;
     };
 
-    treesitter-context = {
-      enable = true;
-      settings = {
-        max_lines = 10;
-        multiline_threshold = 10;
-        trim_scope = "outer";
-        mode = "cursor";
-        separator = "─";
-      };
-    };
-
-    treesitter-textobjects = {
-      enable = true;
-      settings.select = {
-        enable = true;
-        lookahead = true;
-      };
-    };
-
     rainbow-delimiters = {
       enable = true;
     };


### PR DESCRIPTION
未配置完整 keymaps，实际无功能性。移除以精简配置。

**变更：**
- 移除 `treesitter-context`（上下文条插件）
- 移除 `treesitter-textobjects`（结构化文本对象）
- 保留 `treesitter` 核心 + `rainbow-delimiters`