### PR TITLE
refactor: per-filetype indent with separate config file

### DIFF
--- a/config/indent.nix
+++ b/config/indent.nix
@@ -1,0 +1,34 @@
+{
+  # Global indent defaults (spaces, 2-space fallback).
+  config.opts = {
+    expandtab = true;
+    shiftwidth = 2;
+    tabstop = 2;
+    softtabstop = -1;
+    smarttab = true;
+  };
+
+  # Per-filetype overrides for langs that differ from the default.
+  autoCmd = [
+    {
+      event = [ "FileType" ];
+      pattern = [
+        "c"
+        "cpp"
+        "cs"
+        "cuda"
+        "java"
+        "kotlin"
+        "objc"
+        "objcpp"
+        "perl"
+        "php"
+        "python"
+        "rust"
+      ];
+      # 4 spaces: C/C++ ecosystem, C#, CUDA, Java, Kotlin, PEP 8,
+      # Perl, PSR-2 (PHP), rustfmt default
+      command = "setlocal shiftwidth=4 tabstop=4 softtabstop=4";
+    }
+  ];
+}

--- a/config/indent.nix
+++ b/config/indent.nix
@@ -1,34 +1,36 @@
 {
-  # Global indent defaults (spaces, 2-space fallback).
-  config.opts = {
-    expandtab = true;
-    shiftwidth = 2;
-    tabstop = 2;
-    softtabstop = -1;
-    smarttab = true;
-  };
+  config = {
+    # Global indent defaults (spaces, 2-space fallback).
+    opts = {
+      expandtab = true;
+      shiftwidth = 2;
+      tabstop = 2;
+      softtabstop = -1;
+      smarttab = true;
+    };
 
-  # Per-filetype overrides for langs that differ from the default.
-  autoCmd = [
-    {
-      event = [ "FileType" ];
-      pattern = [
-        "c"
-        "cpp"
-        "cs"
-        "cuda"
-        "java"
-        "kotlin"
-        "objc"
-        "objcpp"
-        "perl"
-        "php"
-        "python"
-        "rust"
-      ];
-      # 4 spaces: C/C++ ecosystem, C#, CUDA, Java, Kotlin, PEP 8,
-      # Perl, PSR-2 (PHP), rustfmt default
-      command = "setlocal shiftwidth=4 tabstop=4 softtabstop=4";
-    }
-  ];
+    # Per-filetype overrides for langs that differ from the default.
+    autoCmd = [
+      {
+        event = [ "FileType" ];
+        pattern = [
+          "c"
+          "cpp"
+          "cs"
+          "cuda"
+          "java"
+          "kotlin"
+          "objc"
+          "objcpp"
+          "perl"
+          "php"
+          "python"
+          "rust"
+        ];
+        # 4 spaces: C/C++ ecosystem, C#, CUDA, Java, Kotlin, PEP 8,
+        # Perl, PSR-2 (PHP), rustfmt default
+        command = "setlocal shiftwidth=4 tabstop=4 softtabstop=4";
+      }
+    ];
+  };
 }

--- a/config/settings.nix
+++ b/config/settings.nix
@@ -12,13 +12,6 @@
   };
 
   config.opts = {
-    # Indentation
-    expandtab = true;
-    shiftwidth = 4;
-    tabstop = 4;
-    softtabstop = 0;
-    smarttab = true;
-
     # Encoding
     fileencoding = "utf-8";
 


### PR DESCRIPTION
## Summary

- Indent options (expandtab, shiftwidth, tabstop, softtabstop, smarttab) moved from `config/settings.nix` → new `config/indent.nix`
- Global default changed from hardcoded 4 spaces → 2 spaces
- Per-filetype overrides via FileType autocmd for 4-space languages: c, cpp, cs, cuda, java, kotlin, objc, objcpp, perl, php, python, rust
- All other langs (js/ts/json/yaml/html/lua/bash/nix/terraform/helm/md/vim etc.) inherit 2-space default

Closes the requirement: indent width now varies by language instead of being fixed at 4 spaces globally.