### PR TITLE
feat: add editorconfig and sleuth for auto indent detection

### DIFF
--- a/config/indent.nix
+++ b/config/indent.nix
@@ -1,6 +1,7 @@
 {
   config = {
     # Global indent defaults (spaces, 2-space fallback).
+    # Detection priority: editorconfig → sleuth (file content) → autoCmd → global default
     opts = {
       expandtab = true;
       shiftwidth = 2;

--- a/plugins/tools/editorconfig.nix
+++ b/plugins/tools/editorconfig.nix
@@ -1,7 +1,12 @@
 {
-  # EditorConfig: read .editorconfig files for per-project indent/style.
-  # Falls back to vim defaults (autoCmd in config/indent.nix) when absent.
-  plugins.editorconfig = {
+  # Auto-detect indent from projects with .editorconfig.
+  editorconfig = {
+    enable = true;
+  };
+
+  # Detect indent settings from existing file content.
+  # Covers projects without .editorconfig.
+  plugins.sleuth = {
     enable = true;
   };
 }

--- a/plugins/tools/editorconfig.nix
+++ b/plugins/tools/editorconfig.nix
@@ -1,0 +1,7 @@
+{
+  # EditorConfig: read .editorconfig files for per-project indent/style.
+  # Falls back to vim defaults (autoCmd in config/indent.nix) when absent.
+  plugins.editorconfig = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
## Summary

Adds auto-detection layers so indent width adapts per project/file instead of being hardcoded.

### Detection priority

1. **editorconfig** — reads `.editorconfig` if present (industry standard)
2. **vim-sleuth** — auto-detects from existing file content (covers projects without `.editorconfig`)
3. **autoCmd** — per-filetype fallback (4-space: c/cpp/cs/cuda/java/kotlin/objc/objcpp/perl/php/python/rust)
4. **global default** — 2 spaces, expandtab

### What changed
- `plugins/tools/editorconfig.nix` — enable `editorconfig` + `plugins.sleuth`
- Detection chain documented in `config/indent.nix`

### Stack
- Previous PR #54 extracted indent logic to separate file
- This PR adds auto-detection on top

Closes: uniform spaces with variable width per file/project.