### PR TITLE
fix: disable flash treesitter auto-jump

### DIFF
--- a/plugins/feature/flash.nix
+++ b/plugins/feature/flash.nix
@@ -44,7 +44,7 @@
         restore = false;
         motion = false;
       };
-      # Modes configuration for different case sensitivity
+      # Modes configuration
       modes = {
         search = {
           # Default case insensitive
@@ -52,6 +52,12 @@
         };
         char = {
           enabled = false;
+        };
+        treesitter = {
+          jump = {
+            # Upstream default is true; override to never auto-jump
+            autojump = false;
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary

- Add explicit `modes.treesitter.jump.autojump = false` to flash.nix
- Upstream flash.nvim defaults `autojump = true` for treesitter mode
- nixvim module's default for treesitter mode does NOT override this,
  inheriting only from the top-level `autojump = false`
- Making it explicit prevents future regressions

Closes user request: "唯一匹配时也不会自动跳转"